### PR TITLE
Add Black-Oled

### DIFF
--- a/black-oled.json
+++ b/black-oled.json
@@ -1,0 +1,108 @@
+{
+    "name": "Black-Oled",
+    "variables": {
+        "accent_color": "#62a0ea",
+        "accent_bg_color": "#1a5fb4",
+        "accent_fg_color": "#ffffff",
+        "destructive_color": "#ff7b63",
+        "destructive_bg_color": "#c01c28",
+        "destructive_fg_color": "#ffffff",
+        "success_color": "#2ec27e",
+        "success_bg_color": "#26a269",
+        "success_fg_color": "#ffffff",
+        "warning_color": "#f8e45c",
+        "warning_bg_color": "#cd9309",
+        "warning_fg_color": "rgba(0, 0, 0, 0.8)",
+        "error_color": "#ff7b63",
+        "error_bg_color": "#c01c28",
+        "error_fg_color": "#c0bfbc",
+        "window_bg_color": "#000000",
+        "window_fg_color": "#ffffff",
+        "view_bg_color": "#1e1e1e",
+        "view_fg_color": "#ffffff",
+        "headerbar_bg_color": "#303030",
+        "headerbar_fg_color": "#ffffff",
+        "headerbar_border_color": "#ffffff",
+        "headerbar_backdrop_color": "@window_bg_color",
+        "headerbar_shade_color": "rgba(0, 0, 0, 0.36)",
+        "card_bg_color": "rgba(255, 255, 255, 0.08)",
+        "card_fg_color": "#ffffff",
+        "card_shade_color": "rgba(0, 0, 0, 0.36)",
+        "dialog_bg_color": "#383838",
+        "dialog_fg_color": "#ffffff",
+        "popover_bg_color": "#383838",
+        "popover_fg_color": "#ffffff",
+        "shade_color": "rgba(0, 0, 0, 0.36)",
+        "scrollbar_outline_color": "rgba(0, 0, 0, 0.5)"
+    },
+    "palette": {
+        "blue_": {
+            "1": "#99c1f1",
+            "2": "#62a0ea",
+            "3": "#3584e4",
+            "4": "#1c71d8",
+            "5": "#1a5fb4"
+        },
+        "green_": {
+            "1": "#8ff0a4",
+            "2": "#57e389",
+            "3": "#33d17a",
+            "4": "#2ec27e",
+            "5": "#26a269"
+        },
+        "yellow_": {
+            "1": "#f9f06b",
+            "2": "#f8e45c",
+            "3": "#f6d32d",
+            "4": "#f5c211",
+            "5": "#e5a50a"
+        },
+        "orange_": {
+            "1": "#ffbe6f",
+            "2": "#ffa348",
+            "3": "#ff7800",
+            "4": "#e66100",
+            "5": "#c64600"
+        },
+        "red_": {
+            "1": "#f66151",
+            "2": "#ed333b",
+            "3": "#e01b24",
+            "4": "#c01c28",
+            "5": "#a51d2d"
+        },
+        "purple_": {
+            "1": "#dc8add",
+            "2": "#c061cb",
+            "3": "#9141ac",
+            "4": "#813d9c",
+            "5": "#613583"
+        },
+        "brown_": {
+            "1": "#cdab8f",
+            "2": "#b5835a",
+            "3": "#986a44",
+            "4": "#865e3c",
+            "5": "#63452c"
+        },
+        "light_": {
+            "1": "#ffffff",
+            "2": "#f6f5f4",
+            "3": "#deddda",
+            "4": "#c0bfbc",
+            "5": "#9a9996"
+        },
+        "dark_": {
+            "1": "#77767b",
+            "2": "#5e5c64",
+            "3": "#3d3846",
+            "4": "#241f31",
+            "5": "#000000"
+        }
+    },
+    "custom_css": {
+        "gtk4": "",
+        "gtk3": ""
+    },
+    "plugins": {}
+}


### PR DESCRIPTION
Black Oled is good for save energy in Amolded/Oled Displays, this use a more black pallete colors, in future will have a Gnome Shell Theme using this pallete

# New Preset: <NAME>

<!-- comments -->

## Description

<!-- will be used in the preset list -->

## Palette
  
<!-- a color palette used for this preset -->

- [x] None
  
## Screenshots (optional)

<!-- Will be used in showcase -->

## Wallpaper

<!-- When we are taking screenshots for adding in the preset list on the website, we can use your background. Maybe add a related background here or nothing if it's not important so we are going to use the default background -->

# Checklist 

Before submitting the PR, I checked:

- [ ] I've only modified one preset
- [ ] I've added the URL to my raw preset in `presets.json`
- [x] I've checked the format of each json files I modified
- [ ] (optional) I've added screenshots
- [ ] The preset name is following preset naming guidelines.

## Publication 

- [x] I want to add my preset in the preset list.

Thanks for your submission we will review and merge it as quick as possible.
